### PR TITLE
uvloop 0.17.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "uvloop" %}
-{% set version = "0.16.0" %}
+{% set version = "0.17.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f74bc20c7b67d1c27c72601c78cf95be99d5c2cdd4514502b4f3eb0933ff1228
+  sha256: 0ddf6baf9cf11a1a22c71487f39f15b2cf78eb5bde7e5b45fbb99e8a9d91b9e1
   patches:
     - 0001-Prefer-SO_REUSEPORT-over-uv.SO_REUSEPORT.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - patch     # [unix]
   host:
     - python
-    - cython
+    - cython 0.29.32
     - pip
     - libuv
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,10 +22,9 @@ requirements:
     - {{ compiler('c') }}
     - make      # [unix]
     - patch     # [unix]
-    - python
   host:
     - python
-    - cython 0.29.32
+    - cython
     - pip
     - libuv
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - cython 0.29.32
     - pip
     - libuv
+    - setuptools
+    - wheel
   run:
     - python
     - {{ pin_compatible("libuv", max_pin="x") }}
@@ -40,7 +42,7 @@ test:
     - pip check
 
 about:
-  home: http://github.com/MagicStack/uvloop
+  home: https://github.com/MagicStack/uvloop
   license: MIT OR Apache-2.0
   license_family: Other
   license_file:
@@ -50,7 +52,7 @@ about:
   description: |
     uvloop is a fast, drop-in replacement of the built-in asyncio event loop.
     uvloop is implemented in Cython and uses libuv under the hood.
-  doc_url: http://uvloop.readthedocs.org
+  doc_url: https://uvloop.readthedocs.io/
   dev_url: https://github.com/MagicStack/uvloop
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,8 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --global-option='build_ext' --global-option='--cython-always' --global-option='--use-system-libuv'
+  script:
+    - {{ PYTHON }} -m pip install . -vv --no-deps --global-option='build_ext' --global-option='--cython-always' --global-option='--use-system-libuv'
   skip: true  # [py<37 or win]
 
 requirements:
@@ -21,6 +22,7 @@ requirements:
     - {{ compiler('c') }}
     - make      # [unix]
     - patch     # [unix]
+    - python
   host:
     - python
     - cython 0.29.32

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
 test:
   imports:
     - uvloop
-  require:
+  requires:
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,20 +13,17 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv --global-option='build_ext' --global-option='--cython-always' --global-option='--use-system-libuv'
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --global-option='build_ext' --global-option='--cython-always' --global-option='--use-system-libuv'
   skip: true  # [py<37 or win]
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cython                                 # [build_platform != target_platform]
     - {{ compiler('c') }}
     - make      # [unix]
     - patch     # [unix]
-    - m2-patch  # [win]
   host:
     - python
-    - cython >=0.28
+    - cython 0.29.32
     - pip
     - libuv
   run:
@@ -36,10 +33,15 @@ requirements:
 test:
   imports:
     - uvloop
+  require:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: http://github.com/MagicStack/uvloop
   license: MIT OR Apache-2.0
+  license_family: Other
   license_file:
     - LICENSE-MIT
     - LICENSE-APACHE


### PR DESCRIPTION
**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/MagicStack/uvloop/releases
License: 
- https://github.com/MagicStack/uvloop/blob/v0.17.0/LICENSE-MIT
- https://github.com/MagicStack/uvloop/blob/v0.17.0/LICENSE-APACHE

[Diff between the latest and previous upstream releases](https://github.com/MagicStack/uvloop/compare/v0.16.0...v0.17.0)

Requirements:
 * setup.py:  https://github.com/MagicStack/uvloop/blob/v0.17.0/setup.py

**_Actions:_**

1. Add --no-deps
2. Remove m2-patch
3. Remove cross-compiling packages from build
4. Pin cython to 0.29.32, see https://github.com/MagicStack/uvloop/blob/afb326897c26f01b864f65f016a7f3f80d9db8ad/setup.py#L24
5. Add pip check
6. Add license_family


**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64'
 * Latest version: 0.17.0
 * Release on PyPi:
    * version: 0.17.0
    * date: 2022-09-14T16:50:44
* [PyPi history](https://pypi.org/project/uvloop/#history)
 * Popularity: 
    * 3 months downloads: 12039.0
    * All time:  551716 downloads -  uvloop  0.17.0  Ultra fast implementation of asyncio event loop on top of libuv.  

</details>

**Other checks:**

<details>

1. - [x] Check the pinnings
7. - [x] Verify that the `build_number` is correct
8. - [x] Verify if the package needs `setuptools`
    
9. - [x] Verify if the package needs `wheel`
    
10. - [x] `pip` in test
    
11. - [x] Verify the test section
12. - [x] Verify if the package is `architecture specific`
13. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)

15. - [x] License family is present
    
16. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                       |
|:---------------------------------|
| HPND-sell-variant-MIT-disclaimer |
| MIT                              |
| MIT-0                            |
| MIT-advertising                  |
| MIT-CMU                          |
| MIT-enna                         |
| MIT-feh                          |
| MIT-Modern-Variant               |
| MIT-open-group                   |
| MIT-Wu                           |
| MITNFA                           |
</details>

**Check dependency issues:**

<details>
../aggregate/uvloop-feedstock/recipe/meta.yaml
Dependencies: ['pip', 'cython >=0.28', 'libuv', 'python']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/uvloop-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/uvloop-feedstock/tree/0.17.0)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/uvloop)
* [Diff between upstream and feature branch](https://github.com/conda-forge/uvloop-feedstock/compare/main...AnacondaRecipes:0.17.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/uvloop-feedstock/compare/master...AnacondaRecipes:0.17.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/uvloop-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)


</details>

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 0.17.0 git@github.com:AnacondaRecipes/uvloop-feedstock.git
```
